### PR TITLE
Add Statement Meta-Data to Parsed OFX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ coverage: bin/pytest
 
 .PHONY: black
 black:
-	black setup.py src tests
+	black src tests
 
 .PHONY: mypy
 mypy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ofxstatement-nordigen"
-version = "0.1.1"
+version = "0.1.2a1"
 authors = [
   { name="Jimmy Stammers", email="jimmy.stammers@gmail.com" },
 ]

--- a/src/ofxstatement_nordigen/plugin.py
+++ b/src/ofxstatement_nordigen/plugin.py
@@ -1,6 +1,6 @@
 import json
 from typing import Iterable
-
+from datetime import datetime
 from ofxstatement.plugin import Plugin
 from ofxstatement.parser import StatementParser
 from ofxstatement.statement import Statement, StatementLine
@@ -29,7 +29,15 @@ class NordigenParser(StatementParser[str]):
         process the file.
         """
         with open(self.filename, "r"):
-            return super().parse()
+            statement = super().parse()
+            dates = [
+                line.date for line in statement.lines if isinstance(line.date, datetime)
+            ]
+            if len(dates) > 0:
+                statement.start_date = min(dates)
+                statement.end_date = max(dates)
+            statement.account_id = self.filename.split("/")[-1].split(".")[0]
+            return statement
 
     def split_records(self) -> Iterable[str]:
         """Return iterable object consisting of a line per transaction"""

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -15,6 +15,9 @@ def test_sample() -> None:
             parser = plugin.get_parser(sample_filename)
             statement = parser.parse()
             assert len(statement.lines) > 0
+            assert statement.start_date is not None
+            assert statement.end_date is not None
+            assert statement.account_id is not None
 
 
 @pytest.mark.parametrize("filename", ["test_date.json"])
@@ -30,13 +33,12 @@ def test_parse_record(filename: str) -> None:
     writer = ofx.OfxWriter(statement)
     result = writer.toxml(pretty=True)
 
-    # Get everything between the <STMTTRNRS> and </STMTTRNRS> tags
+    # Get everything between the <STMTTRN> and </STMTTRN> tags
     result = result[
-        result.index("<STMTTRNRS>") : result.index("</STMTTRNRS>") + len("</STMTTRNRS>")
+        result.index("<STMTTRN>") : result.index("</STMTTRN>") + len("</STMTTRN>")
     ]
     expected = expected[
-        expected.index("<STMTTRNRS>") : expected.index("</STMTTRNRS>")
-        + len("</STMTTRNRS>")
+        expected.index("<STMTTRN>") : expected.index("</STMTTRN>") + len("</STMTTRN>")
     ]
 
     assert result == expected


### PR DESCRIPTION
Adds the following meta-data to the parsed OFX file:

- `account_id`
- `start_date` 
- `end_date`

At present, the account_id is inferred from the file name, so there is an implicit assumption that data for the GoCardless account `foo-bar-baz` is saved in `foo-bar-baz.json`. This is not currently enforced, however.
