### PR TITLE
Enable external parser configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,24 +35,33 @@ To verify that the plugin is installed correctly, you can run:
 
     ofxstatement --list-plugins
 
-This should list the `nordigen` plugin among other plugins.
+This should list the ``nordigen`` plugin among other plugins.
 
 Usage
 ================
 
-To use the plugin, you can run the `ofxstatement` command with the `--plugin` option:
+To use the plugin, you can run the ``ofxstatement`` command with the ``--plugin`` option:
 
 .. code-block:: shell
 
     ofxstatement convert -t nordigen <input_file> <output_file>
 
-Replace `<input_file>` with the path to your input file and `<output_file>` with the desired output file name.
+Replace ``<input_file>`` with the path to your input file and ``<output_file>`` with the desired output file name.
 
 The input file should be a JSON of transactions from GoCardless that has the schema defined `here`_.
 
 .. _here: https://developer.gocardless.com/bank-account-data/transactions
 
 The output file will be an OFX file that can be imported into GnuCash or other financial software.
+
+Configuration
+================
+
+Configuration can be edited using the ``ofxstatement edit-config`` command.
+The following parameters are available:
+
+- ``account_id``: The account ID to use for the transactions. This is required.
+- ``currency``: The currency to use for the account. If not specified, the currency will be determined from the transactions.
 
 After you are done
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ofxstatement-nordigen"
-version = "0.1.2a1"
+version = "0.1.2a2"
 authors = [
   { name="Jimmy Stammers", email="jimmy.stammers@gmail.com" },
 ]

--- a/src/ofxstatement_nordigen/plugin.py
+++ b/src/ofxstatement_nordigen/plugin.py
@@ -12,15 +12,19 @@ class NordigenPlugin(Plugin):
     """Retrieves Nordigen transactions and converts them to OFX format."""
 
     def get_parser(self, filename: str) -> "NordigenParser":
-        return NordigenParser(filename)
+        default_ccy = self.settings.get("currency")
+        account_id = self.settings.get("account")
+        return NordigenParser(filename, default_ccy, account_id)
 
 
 class NordigenParser(StatementParser[str]):
-    def __init__(self, filename: str) -> None:
+    def __init__(self, filename: str, currency: str = None, account_id: str = None) -> None:
         super().__init__()
         if not filename.endswith(".json"):
             raise ValueError("Only JSON files are supported")
         self.filename = filename
+        self.currency = currency
+        self.account_id = account_id
 
     def parse(self) -> Statement:
         """Main entry point for parsers
@@ -36,7 +40,8 @@ class NordigenParser(StatementParser[str]):
             if len(dates) > 0:
                 statement.start_date = min(dates)
                 statement.end_date = max(dates)
-            statement.account_id = self.filename.split("/")[-1].split(".")[0]
+            statement.account_id = self.account_id
+            statement.currency = self.currency or statement.currency
             return statement
 
     def split_records(self) -> Iterable[str]:

--- a/src/ofxstatement_nordigen/plugin.py
+++ b/src/ofxstatement_nordigen/plugin.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterable
+from typing import Iterable, Optional
 from datetime import datetime
 from ofxstatement.plugin import Plugin
 from ofxstatement.parser import StatementParser
@@ -18,7 +18,12 @@ class NordigenPlugin(Plugin):
 
 
 class NordigenParser(StatementParser[str]):
-    def __init__(self, filename: str, currency: str = None, account_id: str = None) -> None:
+    def __init__(
+        self,
+        filename: str,
+        currency: Optional[str] = None,
+        account_id: Optional[str] = None,
+    ) -> None:
         super().__init__()
         if not filename.endswith(".json"):
             raise ValueError("Only JSON files are supported")

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -6,6 +6,24 @@ from ofxstatement_nordigen.plugin import NordigenPlugin, NordigenParser
 from ofxstatement import ofx
 
 
+def test_config_sets_account_and_currency() -> None:
+    """Test that account and currency are set correctly when provided in config."""
+    # Create a plugin with specific account and currency settings
+    settings = {"account": "test-account-123", "currency": "EUR"}
+    plugin = NordigenPlugin(UI(), settings)
+
+    here = os.path.dirname(__file__)
+    sample_filename = os.path.join(here, "sample-statement.json")
+    parser = plugin.get_parser(sample_filename)
+
+    assert parser.account_id == settings["account"]
+    assert parser.currency == settings["currency"]
+
+    statement = parser.parse()
+    assert statement.account_id == settings["account"]
+    assert statement.currency == settings["currency"]
+
+
 def test_sample() -> None:
     plugin = NordigenPlugin(UI(), {})
     here = os.path.dirname(__file__)
@@ -17,7 +35,6 @@ def test_sample() -> None:
             assert len(statement.lines) > 0
             assert statement.start_date is not None
             assert statement.end_date is not None
-            assert statement.account_id is not None
 
 
 @pytest.mark.parametrize("filename", ["test_date.json"])


### PR DESCRIPTION
Adds the ability to configure the account id and currency externally.
Addresses the issue in #8