### PR TITLE
Make compatible with banquepopulaire_rives_de_paris data from Gocardless

### DIFF
--- a/src/ofxstatement_nordigen/plugin.py
+++ b/src/ofxstatement_nordigen/plugin.py
@@ -70,7 +70,11 @@ class NordigenParser(StatementParser[str]):
         elif transaction_data.bookingDate:
             statement.date = datetime.combine(transaction_data.bookingDate, datetime.min.time())
         statement.amount = transaction_data.transactionAmount.amount
-        statement.memo = transaction_data.remittanceInformationUnstructured
+        # Handle different types of remittance information
+        if transaction_data.remittanceInformationUnstructured:
+            statement.memo = transaction_data.remittanceInformationUnstructured
+        elif transaction_data.remittanceInformationUnstructuredArray:
+            statement.memo = " ".join(transaction_data.remittanceInformationUnstructuredArray)
         statement.payee = transaction_data.creditorName or transaction_data.debtorName
         statement.date_user = transaction_data.valueDateTime
         statement.check_no = transaction_data.checkId

--- a/src/ofxstatement_nordigen/plugin.py
+++ b/src/ofxstatement_nordigen/plugin.py
@@ -64,7 +64,11 @@ class NordigenParser(StatementParser[str]):
         transaction = json.loads(line)
         transaction_data = NordigenTransactionModel(**transaction)
         statement.id = transaction_data.transactionId
-        statement.date = transaction_data.bookingDateTime
+        # Use bookingDateTime if available, otherwise convert bookingDate to datetime
+        if transaction_data.bookingDateTime:
+            statement.date = transaction_data.bookingDateTime
+        elif transaction_data.bookingDate:
+            statement.date = datetime.combine(transaction_data.bookingDate, datetime.min.time())
         statement.amount = transaction_data.transactionAmount.amount
         statement.memo = transaction_data.remittanceInformationUnstructured
         statement.payee = transaction_data.creditorName or transaction_data.debtorName

--- a/src/ofxstatement_nordigen/schemas.py
+++ b/src/ofxstatement_nordigen/schemas.py
@@ -71,7 +71,7 @@ class NordigenTransactionModel(BaseModel):
     remittanceInformationStructured: Optional[str] = None
     remittanceInformationStructuredArray: Optional[List[str]] = None
     remittanceInformationUnstructured: Optional[str] = None
-    remmittanceInformationUnstructuredArray: Optional[List[str]] = None
+    remittanceInformationUnstructuredArray: Optional[List[str]] = None
     transactionAmount: Amount
     transactionId: Optional[str] = None
     ultimateCreditor: Optional[str] = None

--- a/tests/data/BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json
+++ b/tests/data/BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json
@@ -1,0 +1,12 @@
+{"transactions":
+ {"booked": [
+     {"transactionId": "202500400015",
+      "entryReference": "202500400015",
+      "bookingDate": "2025-05-02",
+      "valueDate": "2025-05-02",
+      "transactionAmount": {"amount": "-8.43", "currency": "EUR"},
+      "remittanceInformationUnstructuredArray": ["CB****2222", "Food Restaurant"],
+      "bankTransactionCode": "XXXXXXX",
+      "internalTransactionId": "YYYYYYYYYYYYYY"}
+ ],
+  "pending": []}}

--- a/tests/data/BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.ofx
+++ b/tests/data/BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.ofx
@@ -1,0 +1,58 @@
+<!--
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:UTF-8
+CHARSET:NONE
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+-->
+<OFX>
+  <SIGNONMSGSRSV1>
+    <SONRS>
+      <STATUS>
+        <CODE>0</CODE>
+        <SEVERITY>INFO</SEVERITY>
+      </STATUS>
+      <DTSERVER>20250503085155</DTSERVER>
+      <LANGUAGE>ENG</LANGUAGE>
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <TRNUID>0</TRNUID>
+      <STATUS>
+        <CODE>0</CODE>
+        <SEVERITY>INFO</SEVERITY>
+      </STATUS>
+      <STMTRS>
+        <BANKACCTFROM>
+          <BANKID/>
+          <ACCTID/>
+          <ACCTTYPE>CHECKING</ACCTTYPE>
+        </BANKACCTFROM>
+        <BANKTRANLIST>
+          <DTSTART/>
+          <DTEND/>
+          <STMTTRN>
+            <TRNTYPE>CHECK</TRNTYPE>
+            <DTPOSTED>20250502</DTPOSTED>
+            <TRNAMT>-8.43</TRNAMT>
+            <FITID>202500400015</FITID>
+            <REFNUM>YYYYYYYYYYYYYY</REFNUM>
+            <MEMO>CB****2222 Food Restaurant</MEMO>
+            <CURRENCY>
+              <CURSYM>EUR</CURSYM>
+            </CURRENCY>
+          </STMTTRN>
+        </BANKTRANLIST>
+        <LEDGERBAL>
+          <BALAMT/>
+          <DTASOF/>
+        </LEDGERBAL>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>

--- a/tests/test_banquepopulaire_rives_de_paris.py
+++ b/tests/test_banquepopulaire_rives_de_paris.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import pytest
+from datetime import datetime, date
+from decimal import Decimal
+
+from ofxstatement.ui import UI
+from ofxstatement import ofx
+from ofxstatement.statement import StatementLine, Currency
+
+from ofxstatement_nordigen.plugin import NordigenPlugin, NordigenParser
+from ofxstatement_nordigen.schemas import NordigenTransactionModel
+
+@pytest.mark.parametrize("filename", ["BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json"])
+def test_banquepopulaire_rives_de_paris(filename: str) -> None:
+    """Test parsing the BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json file."""
+    here = os.path.dirname(__file__)
+    sample_filename = os.path.join(here, "data", filename)
+    expected_filename = sample_filename.replace(".json", ".ofx")
+
+    parser = NordigenParser(sample_filename)
+    statement = parser.parse()
+
+    # Verify the statement properties
+    assert len(statement.lines) == 1
+
+    # Verify the transaction details
+    transaction = statement.lines[0]
+    assert transaction.id == "202500400015"
+    assert transaction.date.date() == date(2025, 5, 2)
+    assert transaction.amount == Decimal("-8.43")
+    assert transaction.currency == Currency("EUR")
+    assert transaction.refnum == "YYYYYYYYYYYYYY"
+
+    # Check if the memo contains the combined information from remittanceInformationUnstructuredArray
+    assert "CB****2222" in transaction.memo
+    assert "Food Restaurant" in transaction.memo
+
+    # Compare with expected OFX output
+    expected = open(expected_filename, "r").read()
+    writer = ofx.OfxWriter(statement)
+    result = writer.toxml(pretty=True)
+
+    # Get everything between the <STMTTRN> and </STMTTRN> tags
+    result = result[
+        result.index("<STMTTRN>") : result.index("</STMTTRN>") + len("</STMTTRN>")
+    ]
+    expected = expected[
+        expected.index("<STMTTRN>") : expected.index("</STMTTRN>") + len("</STMTTRN>")
+    ]
+
+    assert result == expected

--- a/tests/test_banquepopulaire_rives_de_paris.py
+++ b/tests/test_banquepopulaire_rives_de_paris.py
@@ -31,7 +31,7 @@ def test_banquepopulaire_rives_de_paris(filename: str) -> None:
     assert transaction.id == "202500400015"
     assert transaction.date.date() == date(2025, 5, 2)
     assert transaction.amount == Decimal("-8.43")
-    assert transaction.currency == Currency("EUR")
+    assert transaction.currency.symbol == "EUR"
     assert transaction.refnum == "YYYYYYYYYYYYYY"
 
     # Check if the memo contains the combined information from remittanceInformationUnstructuredArray

--- a/tests/test_banquepopulaire_rives_de_paris.py
+++ b/tests/test_banquepopulaire_rives_de_paris.py
@@ -13,7 +13,10 @@ from ofxstatement.statement import StatementLine, Currency
 from ofxstatement_nordigen.plugin import NordigenPlugin, NordigenParser
 from ofxstatement_nordigen.schemas import NordigenTransactionModel
 
-@pytest.mark.parametrize("filename", ["BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json"])
+
+@pytest.mark.parametrize(
+    "filename", ["BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json"]
+)
 def test_banquepopulaire_rives_de_paris(filename: str) -> None:
     """Test parsing the BANQUEPOPULAIRE_RIVES_DE_PARIS_CCBPFRPPMTG.json file."""
     here = os.path.dirname(__file__)
@@ -29,12 +32,22 @@ def test_banquepopulaire_rives_de_paris(filename: str) -> None:
     # Verify the transaction details
     transaction = statement.lines[0]
     assert transaction.id == "202500400015"
+
+    # Fix for mypy: Check that date is not None before accessing date() method
+    assert transaction.date is not None
     assert transaction.date.date() == date(2025, 5, 2)
+
     assert transaction.amount == Decimal("-8.43")
+
+    # Fix for mypy: Check that currency is not None before accessing symbol attribute
+    assert transaction.currency is not None
     assert transaction.currency.symbol == "EUR"
+
     assert transaction.refnum == "YYYYYYYYYYYYYY"
 
     # Check if the memo contains the combined information from remittanceInformationUnstructuredArray
+    # Fix for mypy: Check that memo is not None before using 'in' operator
+    assert transaction.memo is not None
     assert "CB****2222" in transaction.memo
     assert "Food Restaurant" in transaction.memo
 


### PR DESCRIPTION
Hi, I see ofxstatement-nordigen isn't compatible with my bank data from Gocardless, so I have do some change.